### PR TITLE
Update all posters to use community name provided in the event details

### DIFF
--- a/templates/community/poster.svg
+++ b/templates/community/poster.svg
@@ -64,7 +64,7 @@
 
             <text x="50%" y="110" text-anchor="middle">
                 <tspan>Developer Student Clubs</tspan>
-                <tspan dy="1.2em" x="50%">Kenyatta University</tspan>
+                <tspan dy="1.2em" x="50%">{{ event.communityName || 'Community Name' }}</tspan>
             </text>
         </g>
 


### PR DESCRIPTION
Update all posters to use community name provided in the event details rather than hardcoding the community name.